### PR TITLE
Fix novel summary parsing for new API JSON format

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -347,9 +347,12 @@ class MainWindow(QMainWindow):
                 tags_text = ", ".join([f"#{name}" for name in tag_names])
                 details_html += f"<p><b>Теги:</b> {tags_text}</p>"
 
-        raw_summary = self.novel_info.get("summary", "Описание отсутствует.")
-        decoded_summary = self.parser.decode_html_entities(raw_summary)
-        summary = decoded_summary.replace("\n", "<br>")
+        summary = "Описание отсутствует."
+
+        raw_summary = self.novel_info.get("summary")
+        if raw_summary:
+            summary = self.parser.json_to_html(raw_summary.get("content", []), [])
+
         details_html += f'<div style="margin-top: 10px;"><b>Описание:</b><br/>{summary}</div>'
 
         cover_url = (self.novel_info.get("cover", {}) or {}).get("thumbnail")

--- a/src/processing.py
+++ b/src/processing.py
@@ -78,8 +78,9 @@ class ContentProcessor:
             author = novel_info["authors"][0].get("name", "")
 
         summary = ""
-        if novel_info.get("summary"):
-            summary = self.parser.decode_html_entities(novel_info["summary"].strip())
+        raw_summary = novel_info.get("summary")
+        if raw_summary:
+            summary = self.parser.json_to_html(raw_summary.get("content", []), [])
 
         genres: List[str] = []
         if novel_info.get("genres"):


### PR DESCRIPTION
The API changed from HTML string to JSON (`{"content": [...]}`), so I replaced `decode_html_entities()` with `json_to_html()`.