### PR TITLE
fix: обработка summary как dict (TipTap JSON) вместо строки

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -348,8 +348,17 @@ class MainWindow(QMainWindow):
                 details_html += f"<p><b>Теги:</b> {tags_text}</p>"
 
         raw_summary = self.novel_info.get("summary", "Описание отсутствует.")
-        decoded_summary = self.parser.decode_html_entities(raw_summary)
-        summary = decoded_summary.replace("\n", "<br>")
+        # API может возвращать summary как dict (TipTap JSON) или как строку
+        if isinstance(raw_summary, dict):
+            # Структурированный формат TipTap: {"type": "doc", "content": [...]}
+            summary_content = raw_summary.get("content", [])
+            attachments = self.novel_info.get("summary_attachments", [])
+            summary = self.parser.json_to_html(summary_content, attachments)
+        elif isinstance(raw_summary, str):
+            decoded_summary = self.parser.decode_html_entities(raw_summary)
+            summary = decoded_summary.replace("\n", "<br>")
+        else:
+            summary = "Описание отсутствует."
         details_html += f'<div style="margin-top: 10px;"><b>Описание:</b><br/>{summary}</div>'
 
         cover_url = (self.novel_info.get("cover", {}) or {}).get("thumbnail")

--- a/src/processing.py
+++ b/src/processing.py
@@ -79,7 +79,14 @@ class ContentProcessor:
 
         summary = ""
         if novel_info.get("summary"):
-            summary = self.parser.decode_html_entities(novel_info["summary"].strip())
+            raw_summary = novel_info["summary"]
+            # API может возвращать summary как dict (TipTap JSON) или как строку
+            if isinstance(raw_summary, dict):
+                summary_content = raw_summary.get("content", [])
+                attachments = novel_info.get("summary_attachments", [])
+                summary = self.parser.json_to_html(summary_content, attachments)
+            elif isinstance(raw_summary, str):
+                summary = self.parser.decode_html_entities(raw_summary.strip())
 
         genres: List[str] = []
         if novel_info.get("genres"):


### PR DESCRIPTION
API RanobeLIB теперь возвращает summary в формате TipTap JSON: {"type": "doc", "content": [{"type": "paragraph", ...}]} вместо обычной строки. Это вызывало AttributeError: 'dict' object has no attribute 'replace'

Исправления:
- main_window.py: проверка isinstance(raw_summary, dict) с конвертацией через json_to_html()
- processing.py: аналогичная проверка перед decode_html_entities()
- Обратная совместимость: строковый формат summary тоже поддерживается